### PR TITLE
Add PSI_COLD portable cold+minsize function attribute

### DIFF
--- a/include/psi/build/attributes.hpp
+++ b/include/psi/build/attributes.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// PSI_COLD - a portable "this function is rarely executed" attribute that
+// also asks the compiler to optimize its body for size rather than speed.
+//
+// - GCC: [[gnu::cold]] already implies -Os-like codegen for the function
+//   body (GCC's own docs: the cold attribute "informs the compiler that the
+//   function is unlikely to be executed" and the function "is optimized for
+//   size rather than speed").
+//
+// - Clang (this INCLUDES Clang-CL, which defines both __clang__ and
+//   _MSC_VER - __clang__ must be checked before _MSC_VER, see
+//   disable_warnings.hpp for the same ordering requirement):
+//   [[gnu::cold]] is accepted but, unlike GCC, does NOT by itself trigger
+//   size-optimized codegen - LLVM treats "cold" purely as a branch-
+//   probability/code-layout hint, not a size directive. This is a
+//   deliberate LLVM design choice, not an oversight or a bug to work around:
+//   LLVM's own "[PGO] Add ability to mark cold functions as
+//   optsize/minsize/optnone" patch series
+//   (https://reviews.llvm.org/D149800) exists specifically because cold
+//   alone buys no size reduction in LLVM, and a reviewer's comment on that
+//   series states outright why it isn't the default - "fully using
+//   minsize/optnone for cold funcs might have been too big of a hammer
+//   performance-wise" - i.e. LLVM deliberately keeps the two concerns
+//   (branch/layout hinting vs size optimization) separable rather than
+//   coupling them the way GCC does. [[clang::minsize]] is the explicit
+//   opt-in for the size-optimization half GCC gives you for free with cold
+//   alone.
+//
+// - MSVC (real cl.exe, not Clang-CL): no equivalent function attribute was
+//   found - no __declspec analogue for "cold" or "minsize" exists. PSI_COLD
+//   expands to nothing there.
+#if defined( __clang__ )
+#   define PSI_COLD [[ gnu::cold, clang::minsize ]]
+#elif defined( __GNUC__ )
+#   define PSI_COLD [[ gnu::cold ]]
+#else
+#   define PSI_COLD
+#endif


### PR DESCRIPTION
## Summary

New `PSI_COLD` macro in `include/psi/build/attributes.hpp`, abstracting
"this function is rarely executed, optimize its body for size" across
GCC/Clang/MSVC:

- **GCC**: `[[gnu::cold]]` — already implies size-optimized codegen for the
  function body (per GCC's own docs).
- **Clang** (including Clang-CL): `[[gnu::cold, clang::minsize]]`. Clang
  accepts `[[gnu::cold]]` but treats it purely as a branch-probability/
  layout hint — unlike GCC, it does not by itself produce size-optimized
  codegen. This is a deliberate LLVM design choice: see LLVM's own
  "[PGO] Add ability to mark cold functions as optsize/minsize/optnone"
  patch series ([D149800](https://reviews.llvm.org/D149800)), which exists
  specifically because `cold` alone buys no size reduction in LLVM, plus a
  reviewer's explicit rationale there for why the two concerns are kept
  separable rather than coupled the way GCC does. `[[clang::minsize]]` is
  the explicit opt-in for the size-optimization half GCC gives for free.
- **MSVC** (real `cl.exe`, not Clang-CL): no equivalent attribute exists —
  `PSI_COLD` expands to nothing.

`__clang__` is checked before `__GNUC__`/`_MSC_VER` since Clang-CL defines
both `__clang__` and `_MSC_VER` — same ordering requirement already
documented in `disable_warnings.hpp`.

## Motivation

Several downstream consumers (psi.vm, rama) currently spell this out
ad-hoc and inconsistently — some use bare `[[gnu::cold]]`, some already
hand-roll `[[gnu::cold, clang::minsize]]`. Centralizing it avoids the
inconsistency and documents the clang deviation once, with a citation,
instead of re-deriving/re-justifying it at each call site.

## Test plan
- [x] Header-only addition, no build system changes.
- Follow-up PRs will migrate existing cold-attribute call sites in psi.vm
  and rama to this macro once merged.